### PR TITLE
Test out workflow dispatch for publishing docker image

### DIFF
--- a/.github/workflows/_deploy_node_tooling_docker_image.yml
+++ b/.github/workflows/_deploy_node_tooling_docker_image.yml
@@ -14,6 +14,22 @@ on:
         options:
         - ghcr.io/plasmalaboratories
         - stratalab
+      image:
+        description: 'Docker Image to publish'
+        required: true
+        default: 'plasma-node-tooling'
+        type: choice
+        options:
+        - plasma-node-tooling
+        - bitcoin-zmq
+      imageDirectory:
+        description: 'Docker Image Directory'
+        required: true
+        default: './docker/node'
+        type: choice
+        options:
+        - ./docker/node
+        - ./docker/bitcoin
 
 jobs:
   publish:
@@ -36,7 +52,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image (ghcr)
+      - name: Build and push Docker Image
         run: |
-          docker build -t ${{ github.event.inputs.registry }}/plasma-node-tooling:${{ github.event.inputs.imageTag }} .
-          docker push  ${{ github.event.inputs.registry }}/node-tooling:${{ github.event.inputs.imageTag }}
+          docker build -t ${{ github.event.inputs.registry }}/${{ github.event.inputs.image }}:${{ github.event.inputs.imageTag }} .
+          docker push  ${{ github.event.inputs.registry }}/${{ github.event.inputs.image }}:${{ github.event.inputs.imageTag }}
+        working-directory: ${{ github.event.inputs.imageDirectory }}

--- a/.github/workflows/_deploy_node_tooling_docker_image.yml
+++ b/.github/workflows/_deploy_node_tooling_docker_image.yml
@@ -1,0 +1,42 @@
+name: Deploy Node Tooling Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      imageTag:
+        description: 'Docker Image Tag'
+        required: true
+      registry:
+        description: 'Docker Image Registry'
+        required: true
+        default: 'ghcr.io/plasmalaboratories'
+        type: choice
+        options:
+        - ghcr.io/plasmalaboratories
+        - stratalab
+
+jobs:
+  publish:
+    name: Deploy Node Tooling Docker Image
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image (ghcr)
+        run: |
+          docker build -t ${{ github.event.inputs.registry }}/plasma-node-tooling:${{ github.event.inputs.imageTag }} .
+          docker push  ${{ github.event.inputs.registry }}/node-tooling:${{ github.event.inputs.imageTag }}

--- a/.github/workflows/_deploy_node_tooling_docker_image.yml
+++ b/.github/workflows/_deploy_node_tooling_docker_image.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       imageTag:
-        description: 'Docker Image Tag'
+        description: 'Docker Image Tag. Format examples: `0.1.0` `0.1.0-496b5cf`, `latest`, etc.'
         required: true
       registry:
         description: 'Docker Image Registry'


### PR DESCRIPTION
## Purpose
Allow developers to publish the `plasma-node-tooling` Docker image.

## Approach
Implement a manually triggered workflow.

## Testing
Unfortunately, I cannot test this until the workflow is merged into main.

## Tickets
* n/a