### PR TITLE
BN_ do not fix dependency version , Do not merge (wait for a new release)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val commonSettings = Seq(
       "-oDGG",
       "-u",
       "target/test-reports"
-    ),
+    )
   ),
   resolvers ++= Seq(
     Resolver.defaultLocal,
@@ -45,7 +45,7 @@ lazy val commonSettings = Seq(
     "Maven Repo" at "https://repo1.maven.org/maven2/",
     "Bintray" at "https://jcenter.bintray.com/"
   ),
-  testFrameworks += TestFrameworks.MUnit,
+  testFrameworks += TestFrameworks.MUnit
   // PB.protocExecutable := file("/nix/store/53gyjpxxkzrih1bj388ddw0kg8y0qz8j-protobuf-25.4/bin/protoc")
 )
 
@@ -129,7 +129,7 @@ lazy val shared = (project in file("shared"))
     scalapbCodeGeneratorOptions += CodeGeneratorOption.FlatPackage,
     libraryDependencies ++=
       Dependencies.plasmaBtcBridge.shared ++
-        Dependencies.plasmaBtcBridge.test
+      Dependencies.plasmaBtcBridge.test
   )
   .enablePlugins(Fs2Grpc)
 
@@ -142,7 +142,7 @@ lazy val consensus = (project in file("consensus"))
     name := "plasma-btc-bridge-consensus",
     libraryDependencies ++=
       Dependencies.plasmaBtcBridge.consensus ++
-        Dependencies.plasmaBtcBridge.test
+      Dependencies.plasmaBtcBridge.test
   )
   .enablePlugins(DockerPlugin, JavaAppPackaging)
   .dependsOn(shared)
@@ -157,7 +157,7 @@ lazy val publicApi =
       name := "plasma-btc-bridge-public-api",
       libraryDependencies ++=
         Dependencies.plasmaBtcBridge.publicApi ++
-          Dependencies.plasmaBtcBridge.test
+        Dependencies.plasmaBtcBridge.test
     )
     .enablePlugins(DockerPlugin, JavaAppPackaging)
     .dependsOn(shared)
@@ -189,8 +189,7 @@ buildClient := {
   // even after the server is packaged in a fat jar.
   IO.copyDirectory(
     source = (root / baseDirectory).value / "bridge-ui" / "dist",
-    target =
-      (consensus / baseDirectory).value / "src" / "main" / "resources" / "static"
+    target = (consensus / baseDirectory).value / "src" / "main" / "resources" / "static"
   )
 }
 
@@ -201,27 +200,33 @@ lazy val plasmaBtcCli = (project in file("plasma-btc-cli"))
     name := "plasma-btc-cli",
     libraryDependencies ++=
       Dependencies.plasmaBtcBridge.consensus ++
-        Dependencies.plasmaBtcBridge.test
+      Dependencies.plasmaBtcBridge.test
   )
   .enablePlugins(JavaAppPackaging)
   .dependsOn(shared)
 
 lazy val integration = (project in file("integration"))
-  .dependsOn(consensus, publicApi, plasmaBtcCli) // your current subproject
+  .dependsOn(consensus, publicApi, plasmaBtcCli)
   .settings(
     publish / skip := true,
     commonSettings,
-    libraryDependencies ++= Dependencies.plasmaBtcBridge.consensus ++ Dependencies.plasmaBtcBridge.publicApi ++ Dependencies.plasmaBtcBridge.shared ++ Dependencies.plasmaBtcBridge.test
+    libraryDependencies ++=
+      Dependencies.plasmaBtcBridge.consensus ++
+      Dependencies.plasmaBtcBridge.publicApi ++
+      Dependencies.plasmaBtcBridge.shared ++
+      Dependencies.plasmaBtcBridge.test
   )
 
 lazy val `integration-monitor` = (project in file("integration-monitor"))
-  .dependsOn(consensus, plasmaBtcCli) // your current subproject
+  .dependsOn(consensus, plasmaBtcCli)
   .settings(
     publish / skip := true,
     commonSettings,
-    libraryDependencies ++= Dependencies.plasmaBtcBridge.consensus ++ Dependencies.plasmaBtcBridge.shared ++ Dependencies.plasmaBtcBridge.test
+    libraryDependencies ++=
+      Dependencies.plasmaBtcBridge.consensus ++
+      Dependencies.plasmaBtcBridge.shared ++
+      Dependencies.plasmaBtcBridge.test
   )
-
 
 lazy val root = project
   .in(file("."))

--- a/consensus/src/main/scala/org/plasmalabs/bridge/consensus/core/controllers/StartSessionController.scala
+++ b/consensus/src/main/scala/org/plasmalabs/bridge/consensus/core/controllers/StartSessionController.scala
@@ -160,7 +160,6 @@ object StartSessionController {
         someRedeemAdress.isDefined,
         "Redeem address was not generated correctly"
       )
-      bridgeNodeKey = someRedeemAdressAndKey.map(_._2).get
       addressAndsessionInfo <- createPeginSessionInfo(
         btcPeginCurrentWalletIdx,
         btcBridgeCurrentWalletIdx,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   object Versions {
     val catsCoreVersion = "2.12.0"
     val http4sVersion = "0.23.29"
+    val slf4jVersion = "2.0.16"
     val mUnitTeVersion = "0.7.29"
     val bitcoinsVersion = "1.9.9"
     val btcVersionZmq = "1.9.8"
@@ -14,67 +15,68 @@ object Dependencies {
     val ioGrpcVersion = "1.68.1"
   }
 
-  val pekkoActorTyped: Seq[ModuleID] = Seq(
+  private val pekkoActorTyped = Seq(
     "org.apache.pekko" %% "pekko-actor-typed" % "1.0.2"
   )
 
-  val logback: Seq[ModuleID] = Seq(
+  private val logback = Seq(
     "ch.qos.logback" % "logback-classic" % "1.5.12"
   )
 
-  val log4cats: Seq[ModuleID] = Seq(
-    "org.typelevel" %% "log4cats-slf4j" % "2.7.0"
+  private val log4cats = Seq(
+    "org.typelevel" %% "log4cats-slf4j" % "2.7.0",
+    "org.slf4j"      % "slf4j-api"      % slf4jVersion
   )
 
-  val bouncycastle: Seq[ModuleID] = Seq(
+  private val bouncycastle = Seq(
     "org.bouncycastle" % "bcprov-jdk15on" % "1.68",
     "org.bouncycastle" % "bcpkix-jdk15on" % "1.68"
   )
 
-  val plasma: Seq[ModuleID] = Seq(
+  private val plasma = Seq(
     "org.plasmalabs" %% "plasma-sdk"  % plasmaVersion,
     "org.plasmalabs" %% "crypto"      % plasmaVersion,
     "org.plasmalabs" %% "service-kit" % plasmaVersion
   )
 
-  val mUnit: Seq[ModuleID] = Seq(
+  private val mUnit = Seq(
     "org.scalameta" %% "munit"                   % "1.0.2",
     "org.scalameta" %% "munit-scalacheck"        % "1.0.0",
     "org.typelevel" %% "munit-cats-effect"       % "2.0.0",
     "org.typelevel" %% "scalacheck-effect-munit" % "1.0.4"
   )
 
-  val sqlite: Seq[ModuleID] = Seq(
+  private val sqlite = Seq(
     "org.xerial" % "sqlite-jdbc" % "3.47.0.0"
   )
 
-  val ip4score: Seq[ModuleID] = Seq(
+  private val ip4score = Seq(
     "com.comcast" %% "ip4s-core" % "3.6.0"
   )
 
-  val cats: Seq[ModuleID] = Seq(
+  private val cats = Seq(
     "org.typelevel" %% "cats-core"   % catsCoreVersion,
     "org.typelevel" %% "cats-effect" % "3.5.6"
   )
 
-  val grpcNetty: Seq[ModuleID] =
+  private val grpcNetty =
     Seq("io.grpc" % "grpc-netty-shaded" % ioGrpcVersion)
 
-  val grpcRuntime: Seq[ModuleID] =
+  private val grpcRuntime =
     Seq(
       "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
     )
 
-  val scopt: Seq[ModuleID] = Seq("com.github.scopt" %% "scopt" % "4.1.0")
+  private val scopt = Seq("com.github.scopt" %% "scopt" % "4.1.0")
 
-  val http4s: Seq[ModuleID] = Seq(
+  private val http4s = Seq(
     "org.http4s" %% "http4s-ember-client" % http4sVersion,
     "org.http4s" %% "http4s-dsl"          % http4sVersion,
     "org.http4s" %% "http4s-circe"        % http4sVersion,
     "org.http4s" %% "http4s-ember-server" % http4sVersion
   )
 
-  val bitcoinS: Seq[ModuleID] = Seq(
+  private val bitcoinS = Seq(
     "org.bitcoin-s" %% "bitcoin-s-bitcoind-rpc" % bitcoinsVersion,
     "org.bitcoin-s" %% "bitcoin-s-core"         % bitcoinsVersion,
     "org.bitcoin-s" %% "bitcoin-s-chain"        % bitcoinsVersion,
@@ -89,16 +91,16 @@ object Dependencies {
     "org.bitcoin-s" %% "bitcoin-s-zmq"          % btcVersionZmq
   )
 
-  val genericCirce: Seq[ModuleID] = Seq(
+  private val genericCirce = Seq(
     "io.circe" %% "circe-generic" % "0.14.10"
   )
 
-  val optics: Seq[ModuleID] = Seq(
+  private val optics = Seq(
     "dev.optics" %% "monocle-core"  % monocleVersion,
     "dev.optics" %% "monocle-macro" % monocleVersion
   )
 
-  val config: Seq[ModuleID] = Seq(
+  private val config = Seq(
     "com.typesafe" % "config" % "1.4.3"
   )
 
@@ -136,7 +138,6 @@ object Dependencies {
       cats ++
       grpcRuntime ++
       bouncycastle
-
 
     val test: Seq[ModuleID] = mUnit.map(_ % Test)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,6 @@ object Dependencies {
   object Versions {
     val catsCoreVersion = "2.12.0"
     val http4sVersion = "0.23.29"
-    val slf4jVersion = "2.0.16"
     val mUnitTeVersion = "0.7.29"
     val bitcoinsVersion = "1.9.9"
     val btcVersionZmq = "1.9.8"
@@ -15,7 +14,7 @@ object Dependencies {
     val ioGrpcVersion = "1.68.1"
   }
 
-  val akkaSlf4j: Seq[ModuleID] = Seq(
+  val pekkoActorTyped: Seq[ModuleID] = Seq(
     "org.apache.pekko" %% "pekko-actor-typed" % "1.0.2"
   )
 
@@ -23,12 +22,7 @@ object Dependencies {
     "ch.qos.logback" % "logback-classic" % "1.5.12"
   )
 
-  val slf4j: Seq[ModuleID] = Seq(
-    "org.slf4j" % "slf4j-api" % slf4jVersion
-  )
-
   val log4cats: Seq[ModuleID] = Seq(
-    "org.typelevel" %% "log4cats-core"  % "2.7.0",
     "org.typelevel" %% "log4cats-slf4j" % "2.7.0"
   )
 
@@ -121,7 +115,7 @@ object Dependencies {
       grpcNetty ++
       grpcRuntime ++
       sqlite ++
-      akkaSlf4j
+      pekkoActorTyped
 
     val publicApi: Seq[ModuleID] =
       scopt ++
@@ -132,7 +126,6 @@ object Dependencies {
       optics ++
       grpcNetty ++
       grpcRuntime ++
-      slf4j ++
       config ++
       logback ++
       genericCirce


### PR DESCRIPTION
## Wait for external PR
Debug output later and monitor this PR
https://github.com/qos-ch/logback/pull/881

## Purpose
avoid

> 18:53:04.601| ERROR it-test - SLF4J(I): Connected with provider of type [ch.qos.logback.classic.spi.LogbackServiceProvider]

LogDiscovery:

log4cats library, is based on org.slf4j 1(year 2017, current 2.x), and ch.qos.logback 1.2 (year 2023, current 1.5)

https://github.com/typelevel/log4cats/blob/main/.scala-steward.conf


https://mvnrepository.com/artifact/org.typelevel/log4cats-slf4j_3/2.7.0